### PR TITLE
Implementation in python after request from pere

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,33 @@ $ cd etatsbasen-data
 $ etatsbasen
 ```
 
-## Opsjoner
+## Opsjoner (python)
 
-Opsjoner skal ikke være nødvendig. Den har default verdier som er egnet for Mimes brønn
+Opsjoner skal ikke være nødvendig. Den har default verdier som er egnet for Mimes brønn.
+
+```
+$ ./etatsbasen.py -h
+usage: etatsbasen.py [-h] [-c all | -c 12 -c 14 -c ...] [-f file]
+                     [-u headerName1 -u ...] [-v]
+
+Tool for exporting etatsbasen-data to a file that can be imported into
+alaveteli.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c all | -c 12 -c 14 -c ...
+                        Categories to include (default: "all")
+  -f file               File to read from (default: "etatsbasen.csv")
+  -u headerName1 -u ...
+                        Columns and order of columns to output (default: id,re
+                        quest_email,name,name.nn,name.en,tag_string,home_page)
+  -v                    Print version (python-etatsbasen-v0.1) and exit
+```
+
+## Opsjoner (javascript)
+
+Opsjoner skal ikke være nødvendig. Den har default verdier som er egnet for Mimes brønn.
+Dokumentasjonen på opsjonene under er utdatert.
 
 ```sh
 $ etatsbasen -h

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -10,7 +10,7 @@ VERSION="python-etatsbasen-v0.1"
 DEFAULT_CATEGORIES = [12,14,17,18,27,33,38,66,68,76]
 DEFAULT_FILENAME = "etatsbasen-small.csv" # "etatsbasen.csv"
 
-DEFAULT_COLUMNS = ["url_nb","url_en","kommunenummer","orgid","orgstructid","parentid"];
+DEFAULT_COLUMNS = ["id","request_email","name","name.nn","name.en","tag_string","home_page"]
 
 RENAME_HEADERS = {
     'tailid': 'id',

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -8,7 +8,7 @@ import re
 
 VERSION="python-etatsbasen-v0.1"
 DEFAULT_CATEGORIES = [12,14,17,18,27,33,38,66,68,76]
-DEFAULT_FILENAME = "etatsbasen-small.csv" # "etatsbasen.csv"
+DEFAULT_FILENAME = "etatsbasen.csv"
 
 DEFAULT_COLUMNS = ["id","request_email","name","name.nn","name.en","tag_string","home_page"]
 

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -111,6 +111,12 @@ def add_tags(row):
 def add_url(row):
     if row == None:
         return None
+    if row["url_nb"].strip() != "":
+        row["home_page"] = row["url_nb"]
+    elif row ["url_en"].strip() != "":
+        row["home_page"] = row["url_en"]
+    else:
+        row["home_page"] = ""
     return row
 
 def printCSV(options):

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -106,6 +106,7 @@ def trim_row(row):
 def add_tags(row):
     if row == None:
         return None
+    row['tag_string'] = row['orgstructid']
     return row
 
 def add_url(row):

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -1,0 +1,108 @@
+#! /usr/bin/env python3
+import argparse
+import sys
+import os
+from email.utils import parseaddr
+import csv 
+import re
+
+VERSION="python-etatsbasen-v0.1"
+DEFAULT_CATEGORIES = "12,14,17,18,27,33,38,66,68,76"
+DEFAULT_FILENAME = "etatsbasen-small.csv" # "etatsbasen.csv"
+
+def cleanup_email(string):
+    fix1 = re.sub(r"^mailto:?", "", string)
+    if fix1 == valid_email(fix1):
+        return fix1
+    # Split on ' ?[,/] ?'
+    split = re.split(r' ?[,/] ?', string)
+    for fix2 in split:
+        if fix2 == valid_email(fix2):
+            return fix2
+    return False
+
+def valid_email(string):
+    # Think about using https://pypi.python.org/pypi/validate_email ?
+    name, email = parseaddr(string)
+    if (email == string and '@' in email):
+        return email
+
+rename = {
+    'tailid': 'id',
+    'email': 'request_email',
+    'name_nb': 'name',
+    'name_nn': 'name.nn',
+    'name_en': 'name.en'
+  };
+
+def filter_orgstructid(row, categories):
+    if row == None:
+        return None
+    if int(row["orgstructid"]) in categories:
+        return row
+    else:
+        print("Skipping tailid %s: orgstructid not in selected categories (%s not in %s)" % (row['tailid'], row['orgstructid'], categories), file=sys.stderr)
+        return None
+
+def filter_email(row):
+    if row == None:
+        return None
+    if row['email'] == "":
+        print("Skipping tailid %s: No email specified" % (row['tailid']), file=sys.stderr)
+        return None # No email, skip
+    elif not valid_email(row['email']):
+        fixed = cleanup_email(row['email'])
+        if fixed:
+            print("Replaced email for tailid %s: \"%s\" -> \"%s\"" % (row['tailid'], row['email'], fixed), file=sys.stderr)
+            row['email'] = fixed
+        else:
+            print("Skipping tailid %s: Invalid email (%s)" % (row['tailid'], row['email']), file=sys.stderr)
+            return None # Invalid email, skip
+    return row
+
+
+
+def printCSV(options):
+    print(options)
+    with open(options["inputfile"], newline='') as csvfile:
+        reader = csv.DictReader(csvfile, delimiter=',', quotechar='"')
+        filtered_rows = []
+        for row in reader:
+            row = filter_orgstructid(row, options["categories"])
+            row = filter_email(row)
+            if row != None:
+                filtered_rows.append(row)
+    pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Tool for exporting etatsbasen-data to a file that can be imported into alaveteli.')
+    parser.add_argument('-c', metavar="all|c1[,c2,c3,..]", default=DEFAULT_CATEGORIES, help="Categories to include (default: \"%s\")" % (DEFAULT_CATEGORIES))
+    parser.add_argument('-f', metavar="file", default=DEFAULT_FILENAME, help="File to read from (default: \"%s\")" % (DEFAULT_FILENAME))
+    parser.add_argument('-o', metavar="h1[,h2,h3...] ", help="Include only these headers in output (id or name)")
+    parser.add_argument('-v', help="Print version (%s) and exit" % (VERSION), action='store_true')
+    args = parser.parse_args()
+    
+    options = {}
+    
+    if args.v:
+        print("version: %s" % (VERSION))
+        sys.exit(0)
+    
+    if os.path.isfile(args.f):
+        options["inputfile"] =  args.f
+    else:
+        print("%s: No such file" % (args.f), file=sys.stderr)
+        sys.exit(0)
+    
+    if args.o:
+        options["headers"] = args.o.split(',')
+    else:
+        options["headers"] = None
+    try:
+        options["categories"] = [ int(x) for x in args.c.split(',') ]
+    except ValueError as ve:
+        print("Failed to parse \"-c %s\"; Categories must comma separated list of only integers" % (args.c), file=sys.stderr)
+        sys.exit(0)
+    
+    printCSV(options)

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -98,6 +98,17 @@ def trim_row(row):
         trimmed_row[key] = row[key].strip()
     return trimmed_row
 
+
+def add_tags(row):
+    if row == None:
+        return None
+    return row
+
+def add_url(row):
+    if row == None:
+        return None
+    return row
+
 def printCSV(options):
     print(options)
     with open(options["inputfile"], newline='') as csvfile:
@@ -108,7 +119,10 @@ def printCSV(options):
             row = filter_email(row)
             row = renameHeader(row)
             row = trim_row(row)
+            row = add_tags(row)
+            row = add_url(row)
             row = filter_column(row, options["headers"])
+            
             if row != None:
                 filtered_rows.append(row)
     print(filtered_rows)

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -10,7 +10,7 @@ VERSION="python-etatsbasen-v0.1"
 DEFAULT_CATEGORIES = "12,14,17,18,27,33,38,66,68,76"
 DEFAULT_FILENAME = "etatsbasen-small.csv" # "etatsbasen.csv"
 
-DEFAULT_COLUMNS = "url_nb,url_en,kommunenummer,orgid,orgstructid,parentid";
+DEFAULT_COLUMNS = ["url_nb","url_en","kommunenummer","orgid","orgstructid","parentid"];
 
 RENAME_HEADERS = {
     'tailid': 'id',
@@ -110,10 +110,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Tool for exporting etatsbasen-data to a file that can be imported into alaveteli.')
     parser.add_argument('-c', metavar="all|c1[,c2,c3,..]", default=DEFAULT_CATEGORIES, help="Categories to include (default: \"%s\")" % (DEFAULT_CATEGORIES))
     parser.add_argument('-f', metavar="file", default=DEFAULT_FILENAME, help="File to read from (default: \"%s\")" % (DEFAULT_FILENAME))
-    parser.add_argument('-o', metavar="all|headerName1[,headername2,...] ", default=DEFAULT_COLUMNS, help="Include only these headers/columns in output (post-rename)(default: \"%s\")" % (DEFAULT_COLUMNS))
+    parser.add_argument('-o', action='append', metavar="-o headerName1 [-o headername2 ...] ", help="Include only these headers/columns in output (post-rename)(default: \"%s\")" % (DEFAULT_COLUMNS))
     parser.add_argument('-v', help="Print version (%s) and exit" % (VERSION), action='store_true')
     args = parser.parse_args()
-    
     options = {}
     
     if args.v:
@@ -126,10 +125,15 @@ if __name__ == "__main__":
         print("%s: No such file" % (args.f), file=sys.stderr)
         sys.exit(0)
 
-    if args.o == "all":
-        options["headers"] = ["all"]
+    if args.o:
+        for value in args.o:
+            if "," in value:
+                # Hard fail if someone uses old syntax
+                print("Failed to parse \"-o %s\"; Old syntax with comma separated list not supported" % (" -o ".join(args.o)), file=sys.stderr)
+                sys.exit(0)
+        options["headers"] = args.o
     else:
-        options["headers"] = args.o.split(',')
+        options["headers"] = DEFAULT_COLUMNS
 
     try:
         if args.c == "all":
@@ -139,5 +143,5 @@ if __name__ == "__main__":
     except ValueError as ve:
         print("Failed to parse \"-c %s\"; Categories must comma separated list of only integers" % (args.c), file=sys.stderr)
         sys.exit(0)
-    
+
     printCSV(options)

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -7,7 +7,7 @@ import csv
 import re
 
 VERSION="python-etatsbasen-v0.1"
-DEFAULT_CATEGORIES = [12,14,17,18,27,33,38,66,68,76]
+DEFAULT_CATEGORIES = ["all"]
 DEFAULT_FILENAME = "etatsbasen.csv"
 
 DEFAULT_COLUMNS = ["id","request_email","name","name.nn","name.en","tag_string","home_page"]
@@ -146,7 +146,7 @@ def printCSV(options):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Tool for exporting etatsbasen-data to a file that can be imported into alaveteli.')
-    parser.add_argument('-c', action='append', metavar="all | -c 12 -c 14 -c ...", help="Categories to include (default: \"%s\")" % ("all"))
+    parser.add_argument('-c', action='append', metavar="all | -c 12 -c 14 -c ...", help="Categories to include (default: \"%s\")" % (",".join(DEFAULT_CATEGORIES)))
     parser.add_argument('-f', metavar="file", default=DEFAULT_FILENAME, help="File to read from (default: \"%s\")" % (DEFAULT_FILENAME))
     #parser.add_argument('-o', action='append', metavar="-o headerName1 [-o headername2 ...] ", help="(i don't really work) ... Include only these headers/columns in output (post-rename)(default: \"%s\")" % (DEFAULT_COLUMNS))
     parser.add_argument('-u', action='append', metavar="headerName1 -u ...", help="Columns and order of columns to output (default: %s)" % (",".join(DEFAULT_COLUMNS)))
@@ -180,6 +180,6 @@ if __name__ == "__main__":
         except ValueError as ve:
             print("Failed to parse \"-c %s\"; Categories must be integers or only \"-c all\"" % (" -c ".join(args.c)))
     else:
-        options["categories"] = ["all"] #DEFAULT_CATEGORIES
+        options["categories"] = DEFAULT_CATEGORIES
 
     printCSV(options)

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -33,14 +33,14 @@ def cleanup_email(string):
     for fix2 in split:
         if fix2 == valid_email(fix2):
             return fix2
+    fix3 = re.sub(r"\.$", "", string)
+    if fix3 == valid_email(fix3):
+        return fix3
     return False
 
 def valid_email(string):
-    # Think about using https://pypi.python.org/pypi/validate_email ?
-    name, email = parseaddr(string)
-    if (email == string and '@' in email):
-        return email
-
+    if re.match(r"^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$", string):
+        return string
 
 def filter_orgstructid(row, categories):
     if row == None:

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -90,6 +90,14 @@ def filter_column(row, headers):
             filtered_row[key] = row[key]
     return filtered_row
 
+def trim_row(row):
+    if row == None:
+        return None
+    trimmed_row = {}
+    for key in row:
+        trimmed_row[key] = row[key].strip()
+    return trimmed_row
+
 def printCSV(options):
     print(options)
     with open(options["inputfile"], newline='') as csvfile:
@@ -99,6 +107,7 @@ def printCSV(options):
             row = filter_orgstructid(row, options["categories"])
             row = filter_email(row)
             row = renameHeader(row)
+            row = trim_row(row)
             row = filter_column(row, options["headers"])
             if row != None:
                 filtered_rows.append(row)

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -12,6 +12,14 @@ DEFAULT_FILENAME = "etatsbasen-small.csv" # "etatsbasen.csv"
 
 DEFAULT_COLUMNS = "url_nb,url_en,kommunenummer,orgid,orgstructid,parentid";
 
+RENAME_HEADERS = {
+    'tailid': 'id',
+    'email': 'request_email',
+    'name_nb': 'name',
+    'name_nn': 'name.nn',
+    'name_en': 'name.en'
+  };
+
 def cleanup_email(string):
     fix1 = re.sub(r"^mailto:?", "", string)
     if fix1 == valid_email(fix1):
@@ -29,13 +37,6 @@ def valid_email(string):
     if (email == string and '@' in email):
         return email
 
-rename = {
-    'tailid': 'id',
-    'email': 'request_email',
-    'name_nb': 'name',
-    'name_nn': 'name.nn',
-    'name_en': 'name.en'
-  };
 
 def filter_orgstructid(row, categories):
     if row == None:
@@ -47,6 +48,7 @@ def filter_orgstructid(row, categories):
     else:
         print("Skipping tailid %s: orgstructid not in selected categories (%s not in %s)" % (row['tailid'], row['orgstructid'], categories), file=sys.stderr)
         return None
+
 
 def filter_email(row):
     if row == None:
@@ -64,6 +66,17 @@ def filter_email(row):
             return None # Invalid email, skip
     return row
 
+
+def renameHeader(row):
+    if row == None:
+        return None
+    renamed_row = {}
+    for key in row:
+        if key in RENAME_HEADERS:
+            renamed_row[RENAME_HEADERS[key]] = row[key]
+        else:
+            renamed_row[key] = row[key]
+    return renamed_row
 
 
 def filter_column(row, headers):
@@ -85,6 +98,7 @@ def printCSV(options):
         for row in reader:
             row = filter_orgstructid(row, options["categories"])
             row = filter_email(row)
+            row = renameHeader(row)
             row = filter_column(row, options["headers"])
             if row != None:
                 filtered_rows.append(row)

--- a/python/etatsbasen.py
+++ b/python/etatsbasen.py
@@ -38,6 +38,8 @@ rename = {
 def filter_orgstructid(row, categories):
     if row == None:
         return None
+    if len(categories) == 1 and categories[0] == "all":
+        return row
     if int(row["orgstructid"]) in categories:
         return row
     else:
@@ -59,7 +61,6 @@ def filter_email(row):
             print("Skipping tailid %s: Invalid email (%s)" % (row['tailid'], row['email']), file=sys.stderr)
             return None # Invalid email, skip
     return row
-
 
 
 def printCSV(options):
@@ -100,7 +101,10 @@ if __name__ == "__main__":
     else:
         options["headers"] = None
     try:
-        options["categories"] = [ int(x) for x in args.c.split(',') ]
+        if args.c == "all":
+            options["categories"] = ["all"]
+        else:
+            options["categories"] = [ int(x) for x in args.c.split(',') ]
     except ValueError as ve:
         print("Failed to parse \"-c %s\"; Categories must comma separated list of only integers" % (args.c), file=sys.stderr)
         sys.exit(0)


### PR DESCRIPTION
While the options might be different, the output using default values is identical or better.

Most differences (python version output has 6 more rows) arise from a if-error-try-to-fix implementation of email validation, ref differences for tailid 25503, 37924, 22578, 25915, 20989 and 43262

```
> 25503,hedmarken.tingrett@domstol.no,Hedmarken tingrett,Hedmarken tingrett,Hedmarken District Court,19,http://www.domstol.no/hedmarken
> 37924,familievernkontoret.stord@bufetat.no,Familievernkontoret på Stord,Familievernkontoret på Stord,Stord Family Counselling Services,39,http://www.bufetat.no/familievernkontor/stord/
> 22578,fyb@fm.fylkesbibl.no,"Finnmark fylkesbibliotek, avd. Vadsø","Finnmark fylkesbibliotek, avd. Vadsø","Finnmark County Library, Vadsø branch",64,http://www.fm.fylkesbibl.no/web/
> 25915,postmottak@kongsberg.kommune.no,Kongsberg kommune,Kongsberg kommune,Kongsberg Municipality,66,http://www.kongsberg.kommune.no/
> 20989,servicesenteret@larvik.kommune.no,Larvik kommunes serivcesenter,Larvik kommunes serivcesenter,Larvik Municipal Service Centre,73,http://www.larvik.kommune.no/Om-Larvik/Oversikt-over-enheter/Samfunnskontakt/Servicesenteret/
> 43262,post@unn.no,"Senter for psykisk helse Sør-Troms, BUP Sør-Troms (Harstad)","Senter for psykisk helse Sør-Troms, BUP Sør-Troms (Harstad)","Mental health clinic for children and adolescents Sør-Troms, Harstad",39,http://www.unn.no
```

There is also an error in the js version that gives cut-off data if there is a # in a url, ref differences for tailid 34581 and 33662

```
< 33662,registry@eftasurv.int,EFTAs overvåkningsorgan,EFTAs overvåkningsorgan,EFTA Surveillance Authority
> 33662,registry@eftasurv.int,EFTAs overvåkningsorgan,EFTAs overvåkningsorgan,EFTA Surveillance Authority,104,http://www.eftasurv.int/#welcome-no
< 34581,forsvaret@mil.no,Forsvaret,Forsvaret,DEFSTNOR - Defence Staff Norway
> 34581,forsvaret@mil.no,Forsvaret,Forsvaret,DEFSTNOR - Defence Staff Norway,38,http://forsvaret.no/Sider/default.aspx#2
```
